### PR TITLE
[TEST] fix python versions confusion during test execution

### DIFF
--- a/tests/test_onnx_runtime_tvm_package.py
+++ b/tests/test_onnx_runtime_tvm_package.py
@@ -1,5 +1,6 @@
 """Tests ONNX Packaging."""
 import os
+import sys
 import tarfile
 import tempfile
 
@@ -106,7 +107,7 @@ def run_with_custom_op(custom_op_model_name, custom_op_model_dir, input_data):
             input_data_file.write(serialized_input_data)
 
         inference_cmd = [
-            "python",
+            sys.executable,
             "run_inference_in_subprocess.py",
             "--custom_op_model_name",
             custom_op_model_name,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import tempfile
 
 
@@ -6,7 +7,7 @@ def test_package_and_benchmark():
     with tempfile.NamedTemporaryFile() as tfile:
         model_path = tfile.name
         package_cmd = [
-            "python",
+            sys.executable,
             "scripts/onnx_package.py",
             "--input",
             "tests/testdata/abtest.onnx",
@@ -16,6 +17,11 @@ def test_package_and_benchmark():
         result = subprocess.run(package_cmd)
         assert result.returncode == 0
 
-        benchmark_cmd = ["python", "scripts/onnx_benchmark.py", "--model", model_path]
+        benchmark_cmd = [
+            sys.executable,
+            "scripts/onnx_benchmark.py",
+            "--model",
+            model_path,
+        ]
         result = subprocess.run(benchmark_cmd)
         assert result.returncode == 0


### PR DESCRIPTION
Due to using subrocess during test with input string with "python" the python version confusion can occur. If python 2.* is installed it is used during test execution inside subprocess even when tests were launched by python3.\*. It leads to crash due to strong API differences between python 2.* and 3.* versions.
The fix provides launch subprocess with the same python which is used for pytest start.